### PR TITLE
Display only the first layer at page load

### DIFF
--- a/js/mxn/mxn.leaflet.core.js
+++ b/js/mxn/mxn.leaflet.core.js
@@ -310,6 +310,7 @@ Mapstraction: {
 		var url = mxn.util.sanitizeTileURL(tile_url);
 		
 		this.layers[label] = new L.TileLayer(url, options);
+		if(z_index==0)
 		map.addLayer(this.layers[label]);
 		this.tileLayers.push([tile_url, this.layers[label], true, z_index]);
 


### PR DESCRIPTION
Only one layer should be active at load time.